### PR TITLE
TagProvider setup

### DIFF
--- a/src/main/java/muramasa/antimatter/Ref.java
+++ b/src/main/java/muramasa/antimatter/Ref.java
@@ -40,7 +40,7 @@ public class Ref {
 
     /** Debug Options **/
     public static boolean GENERAL_DEBUG = System.getenv("devEnvironment") != null;
-    public static boolean SHOW_STACK_ORE_DICT = true;
+    public static boolean SHOW_ITEM_TAGS = true;
     public static boolean DATA_EXCEPTIONS = false; //TODO re-enable
 
     //TODO maybe use these later

--- a/src/main/java/muramasa/antimatter/client/event/ClientEvents.java
+++ b/src/main/java/muramasa/antimatter/client/event/ClientEvents.java
@@ -4,17 +4,24 @@ import muramasa.antimatter.Ref;
 import muramasa.antimatter.blocks.IInfoProvider;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.Minecraft;
+import net.minecraft.tags.ItemTags;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.StringTextComponent;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
+import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.server.ServerLifecycleHooks;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 @Mod.EventBusSubscriber(modid = Ref.ID, value = Dist.CLIENT)
 public class ClientEvents {
@@ -36,6 +43,21 @@ public class ClientEvents {
             //TODO
             e.getLeft().add("");
             e.getLeft().add(TextFormatting.AQUA + "[GregTech Debug Client]");
+        }
+    }
+
+    @SubscribeEvent
+    public static void onItemTooltip(ItemTooltipEvent e) {
+        if (e.getFlags().isAdvanced() && Ref.SHOW_ITEM_TAGS) {
+            Collection<ResourceLocation> tags = ItemTags.getCollection().getOwningTags(e.getItemStack().getItem());
+            if (!tags.isEmpty()) {
+                List<ITextComponent> list = e.getToolTip();
+                list.add(new StringTextComponent(""));
+                list.add(new StringTextComponent("Tags:").applyTextStyle(TextFormatting.DARK_GRAY));
+                for (ResourceLocation loc : tags) {
+                    list.add(new StringTextComponent(loc.toString()).applyTextStyle(TextFormatting.DARK_GRAY));
+                }
+            }
         }
     }
 }

--- a/src/main/java/muramasa/antimatter/datagen/providers/AntimatterBlockTagProvider.java
+++ b/src/main/java/muramasa/antimatter/datagen/providers/AntimatterBlockTagProvider.java
@@ -1,0 +1,76 @@
+package muramasa.antimatter.datagen.providers;
+
+import muramasa.antimatter.Antimatter;
+import muramasa.antimatter.AntimatterAPI;
+import muramasa.antimatter.Ref;
+import muramasa.antimatter.blocks.BlockStone;
+import muramasa.antimatter.blocks.BlockStorage;
+import muramasa.antimatter.materials.IMaterialTag;
+import muramasa.antimatter.materials.MaterialType;
+import muramasa.antimatter.ore.BlockOre;
+import muramasa.antimatter.ore.StoneType;
+import muramasa.antimatter.util.Utils;
+import net.minecraft.block.Block;
+import net.minecraft.data.BlockTagsProvider;
+import net.minecraft.data.DataGenerator;
+import net.minecraft.tags.Tag;
+import net.minecraftforge.common.Tags;
+import org.apache.commons.lang3.ArrayUtils;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import static muramasa.antimatter.materials.MaterialType.ORE;
+import static muramasa.antimatter.materials.MaterialType.ORE_SMALL;
+import static muramasa.antimatter.util.Utils.*;
+
+public class AntimatterBlockTagProvider extends BlockTagsProvider {
+
+    private String providerDomain, providerName;
+    private boolean replace;
+
+    public AntimatterBlockTagProvider(String providerDomain, String providerName, boolean replace, DataGenerator gen) {
+        super(gen);
+        this.providerDomain = providerDomain;
+        this.providerName = providerName;
+        this.replace = replace;
+    }
+
+    @Override
+    protected void registerTags() {
+        AntimatterAPI.all(StoneType.class).forEach(s -> {
+            IMaterialTag.all(ORE, ORE_SMALL).stream().filter(m -> m.getDomain().equals(providerDomain)).forEach(m -> {
+                if (m.has(ORE)) {
+                    Block block = BlockOre.get(m, ORE, s).getBlock();
+                    String name = String.join("", getConventionalStoneType(s), "_", "ores/", m.getId());
+                    this.getBuilder(getForgeBlockTag(name)).add(block).replace(replace);
+                    this.getBuilder(Tags.Blocks.ORES).add(block);
+                }
+                if (m.has(ORE_SMALL)) {
+                    Block block = BlockOre.get(m, ORE_SMALL, s).getBlock();
+                    String name = String.join("", getConventionalStoneType(s), "_", "small_ores/", m.getId());
+                    this.getBuilder(getForgeBlockTag(name)).add(block).replace(replace);
+                }
+            });
+        });
+        AntimatterAPI.all(BlockStone.class).stream().filter(s -> s.getDomain().equals(providerDomain)).forEach(s -> {
+            this.getBuilder(Tags.Blocks.STONE).add(s);
+            this.getBuilder(getBlockTag(providerDomain, "blocks/".concat(s.getId()))).add(s);
+        });
+        AntimatterAPI.all(BlockStorage.class)
+                .stream().filter(block -> block.getMaterial().getDomain().equals(providerDomain)).forEach(storage -> {
+                    MaterialType type = storage.getType();
+                    this.getBuilder(type.getTag()).add(storage);
+                    String name = String.join("", getConventionalMaterialType(type), "/", storage.getMaterial().getId());
+                    if (storage.getType() == MaterialType.BLOCK) this.getBuilder(Tags.Blocks.SUPPORTS_BEACON).add(storage);
+                    this.getBuilder(getForgeBlockTag(name)).add(storage);
+                });
+    }
+
+    @Override
+    public String getName() {
+        return providerName;
+    }
+
+}

--- a/src/main/java/muramasa/antimatter/datagen/providers/AntimatterBlockTagProvider.java
+++ b/src/main/java/muramasa/antimatter/datagen/providers/AntimatterBlockTagProvider.java
@@ -39,8 +39,12 @@ public class AntimatterBlockTagProvider extends BlockTagsProvider {
 
     @Override
     protected void registerTags() {
+        processTags(providerDomain);
+    }
+
+    public void processTags(String domain) {
         AntimatterAPI.all(StoneType.class).forEach(s -> {
-            IMaterialTag.all(ORE, ORE_SMALL).stream().filter(m -> m.getDomain().equals(providerDomain)).forEach(m -> {
+            IMaterialTag.all(ORE, ORE_SMALL).stream().filter(m -> m.getDomain().equals(domain)).forEach(m -> {
                 if (m.has(ORE)) {
                     Block block = BlockOre.get(m, ORE, s).getBlock();
                     String name = String.join("", getConventionalStoneType(s), "_", "ores/", m.getId());
@@ -54,12 +58,12 @@ public class AntimatterBlockTagProvider extends BlockTagsProvider {
                 }
             });
         });
-        AntimatterAPI.all(BlockStone.class).stream().filter(s -> s.getDomain().equals(providerDomain)).forEach(s -> {
+        AntimatterAPI.all(BlockStone.class).stream().filter(s -> s.getDomain().equals(domain)).forEach(s -> {
             this.getBuilder(Tags.Blocks.STONE).add(s);
-            this.getBuilder(getBlockTag(providerDomain, "blocks/".concat(s.getId()))).add(s);
+            this.getBuilder(getBlockTag(domain, "blocks/".concat(s.getId()))).add(s);
         });
         AntimatterAPI.all(BlockStorage.class)
-                .stream().filter(block -> block.getMaterial().getDomain().equals(providerDomain)).forEach(storage -> {
+                .stream().filter(block -> block.getMaterial().getDomain().equals(domain)).forEach(storage -> {
                     MaterialType type = storage.getType();
                     this.getBuilder(type.getTag()).add(storage);
                     String name = String.join("", getConventionalMaterialType(type), "/", storage.getMaterial().getId());

--- a/src/main/java/muramasa/antimatter/datagen/providers/AntimatterItemTagProvider.java
+++ b/src/main/java/muramasa/antimatter/datagen/providers/AntimatterItemTagProvider.java
@@ -32,6 +32,10 @@ public class AntimatterItemTagProvider extends ItemTagsProvider {
 
     @Override
     protected void registerTags() {
+        processTags(providerDomain);
+    }
+
+    public void processTags(String domain) {
         Tag<Block> blockTag = BLOCK.getTag();
         Tag<Block> frameTag = FRAME.getTag();
         this.copy(Tags.Blocks.ORES, Tags.Items.ORES);
@@ -39,7 +43,7 @@ public class AntimatterItemTagProvider extends ItemTagsProvider {
         this.copy(frameTag, blockToItemTag(frameTag));
         this.copy(Tags.Blocks.STONE, Tags.Items.STONE);
         this.copy(Tags.Blocks.SUPPORTS_BEACON, Tags.Items.SUPPORTS_BEACON);
-        IMaterialTag.all(ORE, ORE_SMALL).stream().filter(m -> m.getDomain().equals(providerDomain)).forEach(m -> {
+        IMaterialTag.all(ORE, ORE_SMALL).stream().filter(m -> m.getDomain().equals(domain)).forEach(m -> {
             AntimatterAPI.all(StoneType.class).forEach(s -> {
                 if (m.has(ORE)) {
                     String name = String.join("", getConventionalStoneType(s), "_", "ores/", m.getId());
@@ -51,18 +55,18 @@ public class AntimatterItemTagProvider extends ItemTagsProvider {
                 }
             });
         });
-        AntimatterAPI.all(BlockStone.class).stream().filter(s -> s.getDomain().equals(providerDomain)).forEach(s -> {
+        AntimatterAPI.all(BlockStone.class).stream().filter(s -> s.getDomain().equals(domain)).forEach(s -> {
             String id = "blocks/".concat(s.getId());
-            this.copy(getBlockTag(providerDomain, id), getItemTag(providerDomain, id));
+            this.copy(getBlockTag(domain, id), getItemTag(domain, id));
         });
         AntimatterAPI.all(BlockStorage.class)
-                .stream().filter(block -> block.getMaterial().getDomain().equals(providerDomain)).forEach(storage -> {
+                .stream().filter(block -> block.getMaterial().getDomain().equals(domain)).forEach(storage -> {
                     MaterialType type = storage.getType();
                     String name = String.join("", getConventionalMaterialType(type), "/", storage.getMaterial().getId());
                     this.copy(getForgeBlockTag(name), getForgeItemTag(name));
                 });
         AntimatterAPI.all(MaterialItem.class).stream()
-                .filter(i -> i.getMaterial().getDomain().equals(providerDomain)).forEach(item -> {
+                .filter(i -> i.getMaterial().getDomain().equals(domain)).forEach(item -> {
                     MaterialType type = item.getType();
                     this.getBuilder(type.getTag()).add(item);
                     String name = String.join("", getConventionalMaterialType(type), "/", item.getMaterial().getId());

--- a/src/main/java/muramasa/antimatter/datagen/providers/AntimatterItemTagProvider.java
+++ b/src/main/java/muramasa/antimatter/datagen/providers/AntimatterItemTagProvider.java
@@ -1,0 +1,79 @@
+package muramasa.antimatter.datagen.providers;
+
+import muramasa.antimatter.AntimatterAPI;
+import muramasa.antimatter.Ref;
+import muramasa.antimatter.blocks.BlockStone;
+import muramasa.antimatter.blocks.BlockStorage;
+import muramasa.antimatter.items.MaterialItem;
+import muramasa.antimatter.materials.IMaterialTag;
+import muramasa.antimatter.materials.MaterialType;
+import muramasa.antimatter.ore.StoneType;
+import muramasa.antimatter.util.Utils;
+import net.minecraft.block.Block;
+import net.minecraft.data.DataGenerator;
+import net.minecraft.data.ItemTagsProvider;
+import net.minecraft.tags.Tag;
+import net.minecraftforge.common.Tags;
+
+import static muramasa.antimatter.materials.MaterialType.*;
+import static muramasa.antimatter.util.Utils.*;
+
+public class AntimatterItemTagProvider extends ItemTagsProvider {
+
+    private String providerDomain, providerName;
+    private boolean replace;
+
+    public AntimatterItemTagProvider(String providerDomain, String providerName, boolean replace, DataGenerator gen) {
+        super(gen);
+        this.providerDomain = providerDomain;
+        this.providerName = providerName;
+        this.replace = replace;
+    }
+
+    @Override
+    protected void registerTags() {
+        Tag<Block> blockTag = BLOCK.getTag();
+        Tag<Block> frameTag = FRAME.getTag();
+        this.copy(Tags.Blocks.ORES, Tags.Items.ORES);
+        this.copy(blockTag, blockToItemTag(blockTag));
+        this.copy(frameTag, blockToItemTag(frameTag));
+        this.copy(Tags.Blocks.STONE, Tags.Items.STONE);
+        this.copy(Tags.Blocks.SUPPORTS_BEACON, Tags.Items.SUPPORTS_BEACON);
+        IMaterialTag.all(ORE, ORE_SMALL).stream().filter(m -> m.getDomain().equals(providerDomain)).forEach(m -> {
+            AntimatterAPI.all(StoneType.class).forEach(s -> {
+                if (m.has(ORE)) {
+                    String name = String.join("", getConventionalStoneType(s), "_", "ores/", m.getId());
+                    this.copy(getForgeBlockTag(name), getForgeItemTag(name));
+                }
+                if (m.has(ORE_SMALL)) {
+                    String name = String.join("", getConventionalStoneType(s), "_", "small_ores/", m.getId());
+                    this.copy(getForgeBlockTag(name), getForgeItemTag(name));
+                }
+            });
+        });
+        AntimatterAPI.all(BlockStone.class).stream().filter(s -> s.getDomain().equals(providerDomain)).forEach(s -> {
+            String id = "blocks/".concat(s.getId());
+            this.copy(getBlockTag(providerDomain, id), getItemTag(providerDomain, id));
+        });
+        AntimatterAPI.all(BlockStorage.class)
+                .stream().filter(block -> block.getMaterial().getDomain().equals(providerDomain)).forEach(storage -> {
+                    MaterialType type = storage.getType();
+                    String name = String.join("", getConventionalMaterialType(type), "/", storage.getMaterial().getId());
+                    this.copy(getForgeBlockTag(name), getForgeItemTag(name));
+                });
+        AntimatterAPI.all(MaterialItem.class).stream()
+                .filter(i -> i.getMaterial().getDomain().equals(providerDomain)).forEach(item -> {
+                    MaterialType type = item.getType();
+                    this.getBuilder(type.getTag()).add(item);
+                    String name = String.join("", getConventionalMaterialType(type), "/", item.getMaterial().getId());
+                    this.getBuilder(getForgeItemTag(name)).add(item).replace(replace);
+                    if (type == INGOT || type == GEM) this.getBuilder(Tags.Items.BEACON_PAYMENT).add(item);
+                });
+    }
+
+    @Override
+    public String getName() {
+        return providerName;
+    }
+
+}

--- a/src/main/java/muramasa/antimatter/materials/MaterialType.java
+++ b/src/main/java/muramasa/antimatter/materials/MaterialType.java
@@ -5,52 +5,57 @@ import muramasa.antimatter.AntimatterAPI;
 import muramasa.antimatter.Ref;
 import muramasa.antimatter.Configs;
 import muramasa.antimatter.registration.IAntimatterObject;
+import muramasa.antimatter.util.Utils;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.tags.Tag;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.StringTextComponent;
 import net.minecraft.util.text.TranslationTextComponent;
 
+import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Set;
 
 public class MaterialType implements IMaterialTag, IAntimatterObject {
 
     //Item Types
-    public static MaterialType DUST = new MaterialType("dust", 2, true, Ref.M);
-    public static MaterialType DUST_SMALL = new MaterialType("dust_small", 2, false, Ref.M / 4);
-    public static MaterialType DUST_TINY = new MaterialType("dust_tiny", 2, false, Ref.M / 9);
-    public static MaterialType DUST_IMPURE = new MaterialType("dust_impure", 2, false, Ref.M);
-    public static MaterialType DUST_PURE = new MaterialType("dust_pure", 2, false, Ref.M);
-    public static MaterialType ROCK = new MaterialType("rock", 2, false, Ref.M / 9);
-    public static MaterialType CRUSHED = new MaterialType("crushed", 2, false, Ref.M);
-    public static MaterialType CRUSHED_CENTRIFUGED = new MaterialType("crushed_centrifuged", 2, false, Ref.M);
-    public static MaterialType CRUSHED_PURIFIED = new MaterialType("crushed_purified", 2, false, Ref.M);
-    public static MaterialType INGOT = new MaterialType("ingot", 2, true, Ref.M);
-    public static MaterialType INGOT_HOT = new MaterialType("ingot_hot", 2, true, Ref.M);
-    public static MaterialType NUGGET = new MaterialType("nugget", 2, false, Ref.M / 9);
-    public static MaterialType GEM = new MaterialType("gem", 2, true, Ref.M);
-    public static MaterialType GEM_BRITTLE = new MaterialType("gem_brittle", 2, true, Ref.M);
-    public static MaterialType GEM_POLISHED = new MaterialType("gem_polished", 2, true, Ref.M);
-    public static MaterialType LENS = new MaterialType("lens", 2, true, Ref.M * 3 / 4);
-    public static MaterialType PLATE = new MaterialType("plate", 2, true, Ref.M);
-    public static MaterialType PLATE_DENSE = new MaterialType("plate_dense", 2, true, Ref.M * 9);
-    public static MaterialType ROD = new MaterialType("rod", 2, true, Ref.M / 2);
-    public static MaterialType ROD_LONG = new MaterialType("rod_long", 2, true, Ref.M);
-    public static MaterialType RING = new MaterialType("ring", 2, true, Ref.M / 4);
-    public static MaterialType FOIL = new MaterialType("foil", 2, true, Ref.M);
-    public static MaterialType BOLT = new MaterialType("bolt", 2, true, Ref.M / 8);
-    public static MaterialType SCREW = new MaterialType("screw", 2, true, Ref.M / 9);
-    public static MaterialType GEAR = new MaterialType("gear", 2, true, Ref.M * 4);
-    public static MaterialType GEAR_SMALL = new MaterialType("gear_small", 2, true, Ref.M);
-    public static MaterialType WIRE_FINE = new MaterialType("wire_fine", 2, true, Ref.M / 8);
-    public static MaterialType SPRING = new MaterialType("spring", 2, true, Ref.M);
-    public static MaterialType ROTOR = new MaterialType("rotor", 2, true, Ref.M * 4 + Ref.M / 4);
+    public static MaterialType DUST = new MaterialType("dust", 2, true, Ref.U);
+    public static MaterialType DUST_SMALL = new MaterialType("dust_small", 2, false, Ref.U4);
+    public static MaterialType DUST_TINY = new MaterialType("dust_tiny", 2, false, Ref.U9);
+    public static MaterialType DUST_IMPURE = new MaterialType("dust_impure", 2, false, Ref.U);
+    public static MaterialType DUST_PURE = new MaterialType("dust_pure", 2, false, Ref.U);
+    public static MaterialType ROCK = new MaterialType("rock", 2, false, Ref.U9);
+    public static MaterialType CRUSHED = new MaterialType("crushed", 2, false, Ref.U);
+    public static MaterialType CRUSHED_CENTRIFUGED = new MaterialType("crushed_centrifuged", 2, false, Ref.U);
+    public static MaterialType CRUSHED_PURIFIED = new MaterialType("crushed_purified", 2, false, Ref.U);
+    public static MaterialType INGOT = new MaterialType("ingot", 2, true, Ref.U);
+    public static MaterialType INGOT_HOT = new MaterialType("ingot_hot", 2, true, Ref.U);
+    public static MaterialType NUGGET = new MaterialType("nugget", 2, false, Ref.U9);
+    public static MaterialType GEM = new MaterialType("gem", 2, true, Ref.U);
+    public static MaterialType GEM_BRITTLE = new MaterialType("gem_brittle", 2, true, Ref.U);
+    public static MaterialType GEM_POLISHED = new MaterialType("gem_polished", 2, true, Ref.U);
+    public static MaterialType LENS = new MaterialType("lens", 2, true, Ref.U * 3 / 4);
+    public static MaterialType PLATE = new MaterialType("plate", 2, true, Ref.U);
+    public static MaterialType PLATE_DENSE = new MaterialType("plate_dense", 2, true, Ref.U * 9);
+    public static MaterialType ROD = new MaterialType("rod", 2, true, Ref.U2);
+    public static MaterialType ROD_LONG = new MaterialType("rod_long", 2, true, Ref.U);
+    public static MaterialType RING = new MaterialType("ring", 2, true, Ref.U4);
+    public static MaterialType FOIL = new MaterialType("foil", 2, true, Ref.U);
+    public static MaterialType BOLT = new MaterialType("bolt", 2, true, Ref.U8);
+    public static MaterialType SCREW = new MaterialType("screw", 2, true, Ref.U9);
+    public static MaterialType GEAR = new MaterialType("gear", 2, true, Ref.U * 4);
+    public static MaterialType GEAR_SMALL = new MaterialType("gear_small", 2, true, Ref.U);
+    public static MaterialType WIRE_FINE = new MaterialType("wire_fine", 2, true, Ref.U8);
+    public static MaterialType SPRING = new MaterialType("spring", 2, true, Ref.U);
+    public static MaterialType ROTOR = new MaterialType("rotor", 2, true, Ref.U * 4 + Ref.U4);
 
     //Dummy Types
-    public static MaterialType ORE = new MaterialType("ore", 1, true, -1, false);
-    public static MaterialType ORE_SMALL = new MaterialType("ore_small", 1, false, -1, false);
-    public static MaterialType BLOCK = new MaterialType("block", 1, false, -1, false);
-    public static MaterialType FRAME = new MaterialType("frame", 1, true, -1, false);
+    public static MaterialType ORE = new MaterialType("ore", 1, true, -1, false, true);
+    public static MaterialType ORE_SMALL = new MaterialType("ore_small", 1, false, -1, false, true);
+    public static MaterialType BLOCK = new MaterialType("block", 1, false, -1, false, true);
+    public static MaterialType FRAME = new MaterialType("frame", 1, true, -1, false, true);
     public static MaterialType TOOLS = new MaterialType("tools", 1, false, -1, false);
     public static MaterialType LIQUID = new MaterialType("liquid", 1, true, -1, false);
     public static MaterialType GAS = new MaterialType("gas", 1, true, -1, false);
@@ -59,8 +64,9 @@ public class MaterialType implements IMaterialTag, IAntimatterObject {
     private String id;
     private ITextComponent namePre, namePost;
     private int unitValue, layers;
-    private boolean active, visible, hasLocName;
+    private boolean active, visible, hasLocName, hasBlock;
     private Set<Material> materials = new LinkedHashSet<>(); //Linked to preserve insertion order for JEI
+    private Map<MaterialType, Tag> tagMap = new HashMap<>();
 
     public MaterialType(String id, int layers, boolean visible, int unitValue) {
         this.id = id;
@@ -68,12 +74,19 @@ public class MaterialType implements IMaterialTag, IAntimatterObject {
         this.unitValue = unitValue;
         this.layers = layers;
         active = true;
+        this.tagMap.put(this, Utils.getForgeItemTag(Utils.getConventionalMaterialType(this)));
         register(MaterialType.class, this);
     }
 
     public MaterialType(String id, int layers, boolean visible, int unitValue, boolean active) {
         this(id, layers, visible, unitValue);
         this.active = active;
+    }
+
+    public MaterialType(String id, int layers, boolean visible, int unitValue, boolean active, boolean hasBlock) {
+        this(id, layers, visible, unitValue, active);
+        this.hasBlock = hasBlock;
+        this.tagMap.put(this, Utils.getForgeBlockTag(Utils.getConventionalMaterialType(this)));
     }
 
     @Override
@@ -87,6 +100,10 @@ public class MaterialType implements IMaterialTag, IAntimatterObject {
 
     public int getLayers() {
         return layers;
+    }
+
+    public <T> Tag<T> getTag() {
+        return tagMap.get(this);
     }
 
     //TODO

--- a/src/main/java/muramasa/antimatter/util/Utils.java
+++ b/src/main/java/muramasa/antimatter/util/Utils.java
@@ -3,15 +3,23 @@ package muramasa.antimatter.util;
 import com.google.common.base.CaseFormat;
 import muramasa.antimatter.Antimatter;
 import muramasa.antimatter.Ref;
+import muramasa.antimatter.materials.MaterialType;
+import muramasa.antimatter.ore.StoneType;
 import muramasa.antimatter.recipe.Recipe;
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.DyeColor;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.network.PacketBuffer;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.tags.ItemTags;
+import net.minecraft.tags.Tag;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockReader;
 import net.minecraftforge.fluids.FluidStack;
@@ -496,8 +504,7 @@ public class Utils {
     public static String underscoreToUpperCamel(String string) {
         return CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, string);
     }
-    
-    //Subscript 0 doesn't get displayed properly for some reason
+
     public static String digitsToSubscript(String string) {
         if (string.length() == 0) return "";
         char[] chars = string.toCharArray();
@@ -526,6 +533,45 @@ public class Utils {
             }
         }
         return original;
+    }
+
+    public static String getConventionalStoneType(StoneType type) {
+        String string = type.getId();
+        int index = string.indexOf("_");
+        if (index != -1) return String.join("", string.substring(index + 1), "_", string.substring(0, index));
+        return string;
+    }
+
+    public static String getConventionalMaterialType(MaterialType type) {
+        String id = type.getId();
+        if (id.contains("crushed")) id = id.replace("crushed", "crushed_ores");
+        int index = id.indexOf("_");
+        if (index != -1) return String.join("", id.substring(index + 1), "_", id.substring(0, index), "s");
+        return id.charAt(id.length() - 1) == 's' ? id.concat("es") : id.concat("s");
+    }
+
+    public static Tag<Block> itemToBlockTag(Tag<Item> tag) {
+        return new BlockTags.Wrapper(tag.getId());
+    }
+
+    public static Tag<Item> blockToItemTag(Tag<Block> tag) {
+        return new ItemTags.Wrapper(tag.getId());
+    }
+
+    public static Tag<Block> getBlockTag(String domain, String name) {
+        return new BlockTags.Wrapper(new ResourceLocation(domain, name));
+    }
+
+    public static Tag<Block> getForgeBlockTag(String name) {
+        return getBlockTag("forge", name);
+    }
+
+    public static Tag<Item> getItemTag(String domain, String name) {
+        return new ItemTags.Wrapper(new ResourceLocation(domain, name));
+    }
+
+    public static Tag<Item> getForgeItemTag(String name) {
+        return getItemTag("forge", name);
     }
 
     public static Recipe getEmptyRecipe() {


### PR DESCRIPTION
Commit msg ->

- AntimatterBlock/ItemTagProviders
- tagMap inside of MaterialType to access created tags from (nearly) each type. (Consideration: can be changed to be a MaterialType property)
- Util methods to get tags, get appropriate names for new mc/forge conventions (Consideration: change our internal naming too?)
- Tooltip event added: can see tags on the fly in advanced mode + SHOW_ITEM_TAGS flag in Ref