### PR TITLE
Fixes more tool related issues

### DIFF
--- a/src/main/java/muramasa/antimatter/client/event/ClientEvents.java
+++ b/src/main/java/muramasa/antimatter/client/event/ClientEvents.java
@@ -46,7 +46,7 @@ import java.util.*;
 @Mod.EventBusSubscriber(modid = Ref.ID, value = Dist.CLIENT)
 public class ClientEvents {
 
-    private static Minecraft MC = Minecraft.getInstance();
+    private static final Minecraft MC = Minecraft.getInstance();
 
     @SubscribeEvent
     public static void onBlockHighlight(DrawHighlightEvent.HighlightBlock event) throws IllegalAccessException {
@@ -57,13 +57,13 @@ public class ClientEvents {
         if (stack.isEmpty() || !(stack.getItem() instanceof IAntimatterTool)) return;
         IAntimatterTool item = (IAntimatterTool) stack.getItem();
         AntimatterToolType type = item.getType();
-        IBehaviour<MaterialTool> behaviour = type.getBehaviour("aoe_break");
+        IBehaviour<IAntimatterTool> behaviour = type.getBehaviour("aoe_break");
         if (!(behaviour instanceof BehaviourAOEBreak)) return;
         BehaviourAOEBreak aoeBreakBehaviour = (BehaviourAOEBreak) behaviour;
 
         BlockPos currentPos = event.getTarget().getPos();
         BlockState state = world.getBlockState(currentPos);
-        if (state.isAir(world, currentPos) || !Utils.isToolEffective(type, state)) return;
+        if (state.isAir(world, currentPos) || !Utils.isToolEffective(item, state)) return;
 
         Vec3d viewPosition = event.getInfo().getProjectedView();
         Entity entity = event.getInfo().getRenderViewEntity();

--- a/src/main/java/muramasa/antimatter/tool/AntimatterItemTier.java
+++ b/src/main/java/muramasa/antimatter/tool/AntimatterItemTier.java
@@ -99,8 +99,7 @@ public class AntimatterItemTier implements IItemTier {
         if (obj == this) return true;
         if (obj == null || obj.getClass() != this.getClass()) return false;
         AntimatterItemTier tier = (AntimatterItemTier) obj;
-        if (primary == tier.getPrimary() && secondary == tier.getSecondary()) return true;
-        return false;
+        return primary == tier.getPrimary() && secondary == tier.getSecondary();
     }
 
     @Override

--- a/src/main/java/muramasa/antimatter/tool/AntimatterToolType.java
+++ b/src/main/java/muramasa/antimatter/tool/AntimatterToolType.java
@@ -31,10 +31,10 @@ public class AntimatterToolType implements IAntimatterObject {
 
     private final String domain, id;
     private final ToolType TOOL_TYPE;
-    private final Set<ToolType> TOOL_TYPES = new HashSet<>();
+    private final Set<String> TOOL_TYPES = new HashSet<>();
     private final Set<Block> EFFECTIVE_BLOCKS = new HashSet<>();
     private final Set<net.minecraft.block.material.Material> EFFECTIVE_MATERIALS = new ObjectOpenHashSet<>();
-    private final Object2ObjectMap<String, IBehaviour<MaterialTool>> behaviours = new Object2ObjectOpenHashMap<>();
+    private final Object2ObjectMap<String, IBehaviour<IAntimatterTool>> behaviours = new Object2ObjectOpenHashMap<>();
     private List<ITextComponent> tooltip = new ArrayList<>();
     private boolean powered, repairable, blockBreakability;
     private long baseMaxEnergy;
@@ -81,8 +81,8 @@ public class AntimatterToolType implements IAntimatterObject {
         this.tag = Utils.getItemTag(new ResourceLocation(Ref.ID, id));
         this.useAction = UseAction.NONE;
         this.toolClass = MaterialTool.class;
-        this.TOOL_TYPE = net.minecraftforge.common.ToolType.get(id);
-        this.TOOL_TYPES.add(TOOL_TYPE);
+        this.TOOL_TYPE = ToolType.get(id);
+        this.TOOL_TYPES.add(id);
         AntimatterAPI.register(this);
     }
 
@@ -182,9 +182,7 @@ public class AntimatterToolType implements IAntimatterObject {
 
     public AntimatterToolType addToolTypes(String... types) {
         if (types.length == 0) Utils.onInvalidData(StringUtils.capitalize(id) + " AntimatterToolType was set to have no additional tool types even when it was explicitly called!");
-        for (String type : types) {
-            this.TOOL_TYPES.add(net.minecraftforge.common.ToolType.get(type));
-        }
+        this.TOOL_TYPES.addAll(Arrays.asList(types));
         return this;
     }
 
@@ -263,22 +261,22 @@ public class AntimatterToolType implements IAntimatterObject {
         return this;
     }
 
-    public void addBehaviour(IBehaviour<MaterialTool>... behaviours) {
+    public void addBehaviour(IBehaviour<IAntimatterTool>... behaviours) {
         Arrays.stream(behaviours).forEach(b -> this.behaviours.put(b.getId(), b));
     }
 
-    public IBehaviour<MaterialTool> getBehaviour(String id) {
+    public IBehaviour<IAntimatterTool> getBehaviour(String id) {
         return behaviours.get(id);
     }
 
     public void removeBehaviour(String... ids) {
-        Arrays.stream(ids).forEach(s -> behaviours.remove(s));
+        Arrays.stream(ids).forEach(behaviours::remove);
     }
 
     /** GETTERS **/
 
-    public ItemStack getToolStack(Material primary, Material secondary) {
-        return AntimatterAPI.get(IAntimatterTool.class, id).asItemStack(primary, secondary);
+    public ItemStack getToolStack(@Nonnull Material primary, @Nonnull Material secondary) {
+        return Objects.requireNonNull(AntimatterAPI.get(IAntimatterTool.class, id)).asItemStack(primary, secondary);
     }
 
     public String getDomain() {
@@ -294,7 +292,7 @@ public class AntimatterToolType implements IAntimatterObject {
         return TOOL_TYPE;
     }
 
-    public Set<ToolType> getToolTypes() {
+    public Set<String> getToolTypes() {
         return TOOL_TYPES;
     }
 
@@ -382,11 +380,8 @@ public class AntimatterToolType implements IAntimatterObject {
         return EFFECTIVE_MATERIALS;
     }
 
-    public Object2ObjectMap<String, IBehaviour<MaterialTool>> getBehaviours() {
+    public Object2ObjectMap<String, IBehaviour<IAntimatterTool>> getBehaviours() {
         return behaviours;
     }
 
-    public ItemStack get(Material m, Material aNull, int i) {
-        return ItemStack.EMPTY;
-    }
 }

--- a/src/main/java/muramasa/antimatter/tool/MaterialSword.java
+++ b/src/main/java/muramasa/antimatter/tool/MaterialSword.java
@@ -2,6 +2,7 @@ package muramasa.antimatter.tool;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
+import mcp.MethodsReturnNonnullByDefault;
 import muramasa.antimatter.AntimatterAPI;
 import muramasa.antimatter.Data;
 import muramasa.antimatter.Ref;
@@ -27,11 +28,15 @@ import net.minecraftforge.common.ToolType;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
-//TODO: power-sensitive version of MaterialSword
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
 public class MaterialSword extends SwordItem implements IAntimatterTool {
 
     protected String domain;
@@ -68,11 +73,24 @@ public class MaterialSword extends SwordItem implements IAntimatterTool {
         return type.isPowered() ? String.join("_", type.getId(), Ref.VN[energyTier].toLowerCase(Locale.ENGLISH)) : type.getId();
     }
 
+    @Nonnull
     @Override
     public AntimatterToolType getType() {
         return type;
     }
 
+    @Nonnull
+    @Override
+    public Set<ToolType> getToolTypes(ItemStack stack) {
+        return type.getToolTypes().stream().map(ToolType::get).collect(Collectors.toSet());
+    }
+
+    /** Returns -1 if its not a powered tool **/
+    public int getEnergyTier() {
+        return energyTier;
+    }
+
+    @Nonnull
     @Override
     public Item asItem() { return this; }
 
@@ -85,7 +103,12 @@ public class MaterialSword extends SwordItem implements IAntimatterTool {
     @Override
     public void fillItemGroup(ItemGroup group, NonNullList<ItemStack> list) {
         if (group != Ref.TAB_TOOLS) return;
-        list.add(asItemStack(Data.NULL, Data.NULL));
+        if (type.isPowered()) {
+            ItemStack stack = asItemStack(Data.NULL, Data.NULL);
+            getDataTag(stack).putLong(Ref.KEY_TOOL_DATA_ENERGY, maxEnergy);
+            list.add(stack);
+        }
+        else list.add(asItemStack(Data.NULL, Data.NULL));
     }
 
     @Override
@@ -116,7 +139,7 @@ public class MaterialSword extends SwordItem implements IAntimatterTool {
 
     @Override
     public boolean canHarvestBlock(ItemStack stack, BlockState state) {
-        return Utils.isToolEffective(type, state) && getTier(stack).getHarvestLevel() >= state.getHarvestLevel();
+        return Utils.isToolEffective(this, state) && getTier(stack).getHarvestLevel() >= state.getHarvestLevel();
     }
 
     @Override
@@ -137,7 +160,7 @@ public class MaterialSword extends SwordItem implements IAntimatterTool {
     @Override
     public float getDestroySpeed(ItemStack stack, BlockState state) {
         if (type.getToolTypes().contains("sword") && state.getBlock() == Blocks.COBWEB) return 15.0F;
-        return Utils.isToolEffective(type, state) ? getTier(stack).getEfficiency() : 1.0F;
+        return Utils.isToolEffective(this, state) ? getTier(stack).getEfficiency() : 1.0F;
     }
 
     @Override

--- a/src/main/java/muramasa/antimatter/tool/MaterialTool.java
+++ b/src/main/java/muramasa/antimatter/tool/MaterialTool.java
@@ -2,6 +2,7 @@ package muramasa.antimatter.tool;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
+import mcp.MethodsReturnNonnullByDefault;
 import muramasa.antimatter.AntimatterAPI;
 import muramasa.antimatter.Data;
 import muramasa.antimatter.Ref;
@@ -26,9 +27,13 @@ import net.minecraftforge.common.ToolType;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
 public class MaterialTool extends ToolItem implements IAntimatterTool {
 
     protected final String domain;
@@ -69,9 +74,10 @@ public class MaterialTool extends ToolItem implements IAntimatterTool {
     @Override
     public AntimatterToolType getType() { return type; }
 
+    @Nonnull
     @Override
     public Set<ToolType> getToolTypes(ItemStack stack) {
-        return type.getToolTypes();
+        return getToolTypes();
     }
 
     /** Returns -1 if its not a powered tool **/
@@ -79,6 +85,7 @@ public class MaterialTool extends ToolItem implements IAntimatterTool {
         return energyTier;
     }
 
+    @Nonnull
     @Override
     public Item asItem() {
         return this;
@@ -93,7 +100,12 @@ public class MaterialTool extends ToolItem implements IAntimatterTool {
     @Override
     public void fillItemGroup(ItemGroup group, NonNullList<ItemStack> list) {
         if (group != Ref.TAB_TOOLS) return;
-        list.add(asItemStack(Data.NULL, Data.NULL));
+        if (type.isPowered()) {
+            ItemStack stack = asItemStack(Data.NULL, Data.NULL);
+            getDataTag(stack).putLong(Ref.KEY_TOOL_DATA_ENERGY, maxEnergy);
+            list.add(stack);
+        }
+        else list.add(asItemStack(Data.NULL, Data.NULL));
     }
 
     @Override
@@ -131,7 +143,7 @@ public class MaterialTool extends ToolItem implements IAntimatterTool {
 
     @Override
     public boolean canHarvestBlock(ItemStack stack, BlockState state) {
-        return Utils.isToolEffective(type, state) && getTier(stack).getHarvestLevel() >= state.getHarvestLevel();
+        return Utils.isToolEffective(this, state) && getTier(stack).getHarvestLevel() >= state.getHarvestLevel();
     }
 
     @Override
@@ -151,7 +163,7 @@ public class MaterialTool extends ToolItem implements IAntimatterTool {
 
     @Override
     public float getDestroySpeed(ItemStack stack, BlockState state) {
-        return Utils.isToolEffective(type, state) ? getTier(stack).getEfficiency() : 1.0F;
+        return Utils.isToolEffective(this, state) ? getTier(stack).getEfficiency() : 1.0F;
     }
 
     @Override

--- a/src/main/java/muramasa/antimatter/tool/behaviour/BehaviourAOEBreak.java
+++ b/src/main/java/muramasa/antimatter/tool/behaviour/BehaviourAOEBreak.java
@@ -1,6 +1,7 @@
 package muramasa.antimatter.tool.behaviour;
 
 import muramasa.antimatter.behaviour.IBlockDestroyed;
+import muramasa.antimatter.tool.IAntimatterTool;
 import muramasa.antimatter.tool.MaterialTool;
 import muramasa.antimatter.util.Utils;
 import net.minecraft.block.BlockState;
@@ -10,7 +11,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
-public class BehaviourAOEBreak implements IBlockDestroyed<MaterialTool> {
+public class BehaviourAOEBreak implements IBlockDestroyed<IAntimatterTool> {
 
     protected int column, row, depth;
 
@@ -39,7 +40,7 @@ public class BehaviourAOEBreak implements IBlockDestroyed<MaterialTool> {
     }
 
     @Override
-    public boolean onBlockDestroyed(MaterialTool instance, ItemStack stack, World world, BlockState state, BlockPos pos, LivingEntity entity) {
+    public boolean onBlockDestroyed(IAntimatterTool instance, ItemStack stack, World world, BlockState state, BlockPos pos, LivingEntity entity) {
         //if(!super.onBlockDestroyed(stack, world, state, pos, entity)) return false;
         if (!(entity instanceof PlayerEntity)) return true;
         PlayerEntity player = (PlayerEntity) entity;

--- a/src/main/java/muramasa/antimatter/tool/behaviour/BehaviourBlockRotate.java
+++ b/src/main/java/muramasa/antimatter/tool/behaviour/BehaviourBlockRotate.java
@@ -1,13 +1,16 @@
 package muramasa.antimatter.tool.behaviour;
 
 import muramasa.antimatter.behaviour.IItemUse;
+import muramasa.antimatter.tool.IAntimatterTool;
 import muramasa.antimatter.tool.MaterialTool;
 import net.minecraft.block.BlockState;
 import net.minecraft.item.ItemUseContext;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Rotation;
 
-public class BehaviourBlockRotate implements IItemUse<MaterialTool> {
+public class BehaviourBlockRotate implements IItemUse<IAntimatterTool> {
+
+    public static final BehaviourBlockRotate INSTANCE = new BehaviourBlockRotate();
 
     @Override
     public String getId() {
@@ -15,10 +18,11 @@ public class BehaviourBlockRotate implements IItemUse<MaterialTool> {
     }
 
     @Override
-    public ActionResultType onItemUse(MaterialTool instance, ItemUseContext c) {
+    public ActionResultType onItemUse(IAntimatterTool instance, ItemUseContext c) {
         BlockState state = c.getWorld().getBlockState(c.getPos());
         if (state.getBlock().getValidRotations(state, c.getWorld(), c.getPos()) != null && c.getPlayer() != null) {
             state.rotate(c.getWorld(), c.getPos(), c.getPlayer().isCrouching() ? Rotation.CLOCKWISE_90 : Rotation.COUNTERCLOCKWISE_90);
+            c.getItem().damageItem(instance.getType().getUseDurability(), c.getPlayer(), (p) -> p.sendBreakAnimation(c.getHand()));
             return ActionResultType.SUCCESS;
         }
         return ActionResultType.PASS;

--- a/src/main/java/muramasa/antimatter/tool/behaviour/BehaviourBlockTilling.java
+++ b/src/main/java/muramasa/antimatter/tool/behaviour/BehaviourBlockTilling.java
@@ -4,25 +4,25 @@ import com.google.common.collect.ImmutableMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import muramasa.antimatter.behaviour.IItemUse;
+import muramasa.antimatter.tool.IAntimatterTool;
 import muramasa.antimatter.tool.MaterialTool;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemUseContext;
-import net.minecraft.util.ActionResultType;
-import net.minecraft.util.Direction;
-import net.minecraft.util.SoundCategory;
-import net.minecraft.util.SoundEvents;
+import net.minecraft.util.*;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.UseHoeEvent;
 import net.minecraftforge.eventbus.api.Event;
 
-public class BehaviourBlockTilling implements IItemUse<MaterialTool> {
+public class BehaviourBlockTilling implements IItemUse<IAntimatterTool> {
 
-    public static final Object2ObjectMap<BlockState, BlockState> TILLING_MAP = new Object2ObjectOpenHashMap<>();
+    public static final BehaviourBlockTilling INSTANCE = new BehaviourBlockTilling();
+
+    private static final Object2ObjectMap<BlockState, BlockState> TILLING_MAP = new Object2ObjectOpenHashMap<>();
 
     static {
         ImmutableMap.of(Blocks.GRASS_BLOCK, Blocks.FARMLAND, Blocks.GRASS_PATH, Blocks.FARMLAND, Blocks.DIRT, Blocks.FARMLAND, Blocks.COARSE_DIRT, Blocks.DIRT)
@@ -35,19 +35,16 @@ public class BehaviourBlockTilling implements IItemUse<MaterialTool> {
     }
 
     @Override
-    public ActionResultType onItemUse(MaterialTool instance, ItemUseContext c) {
-        World world = c.getWorld();
-        BlockPos pos = c.getPos();
-        if (c.getFace() != Direction.DOWN && world.isAirBlock(pos.up())) {
-            BlockState blockstate = TILLING_MAP.get(world.getBlockState(pos));
+    public ActionResultType onItemUse(IAntimatterTool instance, ItemUseContext c) {
+        if (c.getFace() != Direction.DOWN && c.getWorld().isAirBlock(c.getPos().up())) {
+            BlockState blockstate = TILLING_MAP.get(c.getWorld().getBlockState(c.getPos()));
             if (blockstate == null) return ActionResultType.PASS;
-            UseHoeEvent event = new UseHoeEvent(c);
-            MinecraftForge.EVENT_BUS.post(event);
-            PlayerEntity player = c.getPlayer();
-            if (event.getResult() != Event.Result.ALLOW) return ActionResultType.PASS;
-            c.getItem().damageItem(instance.getType().getUseDurability(), player, (p) -> p.sendBreakAnimation(c.getHand()));
-            world.playSound(player, pos, SoundEvents.ITEM_HOE_TILL, SoundCategory.BLOCKS, 1.0F, 1.0F);
-            world.setBlockState(pos, blockstate, 11);
+            UseHoeEvent hoeEvent = new UseHoeEvent(c);
+            if (MinecraftForge.EVENT_BUS.post(hoeEvent)) return ActionResultType.PASS;
+            c.getItem().damageItem(instance.getType().getUseDurability(), c.getPlayer(), (p) -> p.sendBreakAnimation(c.getHand()));
+            SoundEvent soundEvent = instance.getType().getUseSound() == null ? SoundEvents.ITEM_HOE_TILL : instance.getType().getUseSound();
+            c.getWorld().playSound(c.getPlayer(), c.getPos(), soundEvent, SoundCategory.BLOCKS, 1.0F, 1.0F);
+            if (!c.getWorld().isRemote) c.getWorld().setBlockState(c.getPos(), blockstate, 11);
             return ActionResultType.SUCCESS;
         }
         return ActionResultType.PASS;

--- a/src/main/java/muramasa/antimatter/tool/behaviour/BehaviourLogStripping.java
+++ b/src/main/java/muramasa/antimatter/tool/behaviour/BehaviourLogStripping.java
@@ -3,6 +3,7 @@ package muramasa.antimatter.tool.behaviour;
 import com.google.common.collect.ImmutableMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import muramasa.antimatter.behaviour.IItemUse;
+import muramasa.antimatter.tool.IAntimatterTool;
 import muramasa.antimatter.tool.MaterialTool;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
@@ -13,9 +14,11 @@ import net.minecraft.util.ActionResultType;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvents;
 
-public class BehaviourLogStripping implements IItemUse<MaterialTool> {
+public class BehaviourLogStripping implements IItemUse<IAntimatterTool> {
 
-    public static final Object2ObjectOpenHashMap<BlockState, BlockState> STRIPPING_MAP = new Object2ObjectOpenHashMap<>();
+    public static final BehaviourLogStripping INSTANCE = new BehaviourLogStripping();
+
+    private static final Object2ObjectOpenHashMap<BlockState, BlockState> STRIPPING_MAP = new Object2ObjectOpenHashMap<>();
 
     static {
         new ImmutableMap.Builder<Block, Block>().put(Blocks.OAK_WOOD, Blocks.STRIPPED_OAK_WOOD).put(Blocks.OAK_LOG, Blocks.STRIPPED_OAK_LOG).put(Blocks.DARK_OAK_WOOD, Blocks.STRIPPED_DARK_OAK_WOOD)
@@ -31,7 +34,7 @@ public class BehaviourLogStripping implements IItemUse<MaterialTool> {
     }
 
     @Override
-    public ActionResultType onItemUse(MaterialTool instance, ItemUseContext c) {
+    public ActionResultType onItemUse(IAntimatterTool instance, ItemUseContext c) {
         BlockState state = c.getWorld().getBlockState(c.getPos());
         BlockState stripped = STRIPPING_MAP.get(state);
         if (stripped != null) {
@@ -40,7 +43,7 @@ public class BehaviourLogStripping implements IItemUse<MaterialTool> {
             }
             c.getWorld().playSound(c.getPlayer(), c.getPos(), SoundEvents.ITEM_AXE_STRIP, SoundCategory.BLOCKS, 1.0F, 1.0F);
             c.getWorld().setBlockState(c.getPos(), stripped);
-            if (c.getPlayer() != null) c.getPlayer().getHeldItem(c.getHand()).damageItem(instance.getType().getUseDurability(), c.getPlayer(), (onBroken) -> onBroken.sendBreakAnimation(c.getHand()));
+            c.getItem().damageItem(instance.getType().getUseDurability(), c.getPlayer(), (p) -> p.sendBreakAnimation(c.getHand()));
             return ActionResultType.SUCCESS;
         }
         return ActionResultType.PASS;

--- a/src/main/java/muramasa/antimatter/tool/behaviour/BehaviourPoweredDebug.java
+++ b/src/main/java/muramasa/antimatter/tool/behaviour/BehaviourPoweredDebug.java
@@ -2,6 +2,7 @@ package muramasa.antimatter.tool.behaviour;
 
 import muramasa.antimatter.Ref;
 import muramasa.antimatter.behaviour.IItemUse;
+import muramasa.antimatter.tool.IAntimatterTool;
 import muramasa.antimatter.tool.MaterialTool;
 import net.minecraft.block.Blocks;
 import net.minecraft.item.ItemStack;
@@ -9,7 +10,10 @@ import net.minecraft.item.ItemUseContext;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.ActionResultType;
 
-public class BehaviourPoweredDebug implements IItemUse<MaterialTool> {
+// TODO: REPLACE WITH CAPABILITY
+public class BehaviourPoweredDebug implements IItemUse<IAntimatterTool> {
+
+    public static final BehaviourPoweredDebug INSTANCE = new BehaviourPoweredDebug();
 
     @Override
     public String getId() {
@@ -17,7 +21,7 @@ public class BehaviourPoweredDebug implements IItemUse<MaterialTool> {
     }
 
     @Override
-    public ActionResultType onItemUse(MaterialTool instance, ItemUseContext c) {
+    public ActionResultType onItemUse(IAntimatterTool instance, ItemUseContext c) {
         if (instance.getType().isPowered() && c.getWorld().getBlockState(c.getPos()) == Blocks.REDSTONE_BLOCK.getDefaultState() && c.getPlayer() != null) {
             ItemStack stack = c.getPlayer().getHeldItem(c.getHand());
             CompoundNBT nbt = instance.getDataTag(stack);

--- a/src/main/java/muramasa/antimatter/tool/behaviour/BehaviourTreeFelling.java
+++ b/src/main/java/muramasa/antimatter/tool/behaviour/BehaviourTreeFelling.java
@@ -3,6 +3,7 @@ package muramasa.antimatter.tool.behaviour;
 import muramasa.antimatter.AntimatterConfig;
 import muramasa.antimatter.behaviour.IBlockDestroyed;
 import muramasa.antimatter.tool.AntimatterToolType;
+import muramasa.antimatter.tool.IAntimatterTool;
 import muramasa.antimatter.tool.MaterialTool;
 import muramasa.antimatter.util.Utils;
 import net.minecraft.block.BlockState;
@@ -16,7 +17,9 @@ import net.minecraft.world.World;
 import static muramasa.antimatter.Data.AXE;
 import static muramasa.antimatter.Data.CHAINSAW;
 
-public class BehaviourTreeFelling implements IBlockDestroyed<MaterialTool> {
+public class BehaviourTreeFelling implements IBlockDestroyed<IAntimatterTool> {
+
+    public static final BehaviourTreeFelling INSTANCE = new BehaviourTreeFelling();
 
     @Override
     public String getId() {
@@ -24,17 +27,13 @@ public class BehaviourTreeFelling implements IBlockDestroyed<MaterialTool> {
     }
 
     @Override
-    public boolean onBlockDestroyed(MaterialTool instance, ItemStack stack, World world, BlockState state, BlockPos pos, LivingEntity entity) {
+    public boolean onBlockDestroyed(IAntimatterTool instance, ItemStack stack, World world, BlockState state, BlockPos pos, LivingEntity entity) {
+        if (!AntimatterConfig.GAMEPLAY.AXE_TIMBER) return true;
         if (entity instanceof PlayerEntity) {
             PlayerEntity player = (PlayerEntity) entity;
-            AntimatterToolType type = instance.getType();
-            boolean isToolEffective = Utils.isToolEffective(type, state);
-            if (isToolEffective && !player.isCrouching()) { // Only when player isn't shifting/crouching this ability activates
-                if (type == CHAINSAW || instance.getTier().getHarvestLevel() > 1 && (type == AXE || type.getToolTypes().contains("axe"))) {
-                    if (!AntimatterConfig.GAMEPLAY.AXE_TIMBER) return true;
-                    if (state.getBlock().isIn(BlockTags.LOGS)) {
-                        Utils.treeLogging(instance, stack, pos, player, world);
-                    }
+            if (Utils.isToolEffective(instance, state) && !player.isCrouching()) { // Only when player isn't shifting/crouching this ability activates
+                if (state.getBlock().isIn(BlockTags.LOGS)) {
+                    Utils.treeLogging(instance, stack, pos, player, world);
                 }
             }
         }

--- a/src/main/java/muramasa/antimatter/tool/behaviour/BehaviourVanillaShovel.java
+++ b/src/main/java/muramasa/antimatter/tool/behaviour/BehaviourVanillaShovel.java
@@ -1,0 +1,41 @@
+package muramasa.antimatter.tool.behaviour;
+
+import muramasa.antimatter.behaviour.IItemUse;
+import muramasa.antimatter.tool.IAntimatterTool;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.CampfireBlock;
+import net.minecraft.item.ItemUseContext;
+import net.minecraft.util.*;
+
+public class BehaviourVanillaShovel implements IItemUse<IAntimatterTool> {
+
+    public static final BehaviourVanillaShovel INSTANCE = new BehaviourVanillaShovel();
+
+    @Override
+    public String getId() {
+        return "vanilla_shovel";
+    }
+
+    @Override
+    public ActionResultType onItemUse(IAntimatterTool instance, ItemUseContext c) {
+        if (c.getFace() == Direction.DOWN) return ActionResultType.PASS;
+        BlockState state = c.getWorld().getBlockState(c.getPos());
+        BlockState changedState = null;
+        if (state.getBlock() == Blocks.GRASS_BLOCK && c.getWorld().isAirBlock(c.getPos().up())) {
+            SoundEvent soundEvent = instance.getType().getUseSound() == null ? SoundEvents.ITEM_SHOVEL_FLATTEN : instance.getType().getUseSound();
+            c.getWorld().playSound(c.getPlayer(), c.getPos(), soundEvent, SoundCategory.BLOCKS, 1.0F, 1.0F);
+            changedState = Blocks.GRASS_PATH.getDefaultState();
+        }
+        else if (state.getBlock() instanceof CampfireBlock && state.get(CampfireBlock.LIT)) {
+            c.getWorld().playEvent(c.getPlayer(), 1009, c.getPos(), 0);
+            changedState = state.with(CampfireBlock.LIT, false);
+        }
+        if (changedState != null) {
+            c.getWorld().setBlockState(c.getPos(), changedState, 11);
+            c.getItem().damageItem(instance.getType().getUseDurability(), c.getPlayer(), (p) -> p.sendBreakAnimation(c.getHand()));
+            return ActionResultType.SUCCESS;
+        }
+        else return ActionResultType.PASS;
+    }
+}

--- a/src/main/java/muramasa/antimatter/tool/behaviour/BehaviourWaterlogToggle.java
+++ b/src/main/java/muramasa/antimatter/tool/behaviour/BehaviourWaterlogToggle.java
@@ -1,6 +1,7 @@
 package muramasa.antimatter.tool.behaviour;
 
 import muramasa.antimatter.behaviour.IItemUse;
+import muramasa.antimatter.tool.IAntimatterTool;
 import muramasa.antimatter.tool.MaterialTool;
 import net.minecraft.block.BlockState;
 import net.minecraft.item.ItemUseContext;
@@ -9,7 +10,9 @@ import net.minecraft.util.ActionResultType;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvents;
 
-public class BehaviourWaterlogToggle implements IItemUse<MaterialTool> {
+public class BehaviourWaterlogToggle implements IItemUse<IAntimatterTool> {
+
+    public static final BehaviourWaterlogToggle INSTANCE = new BehaviourWaterlogToggle();
 
     @Override
     public String getId() {
@@ -17,7 +20,7 @@ public class BehaviourWaterlogToggle implements IItemUse<MaterialTool> {
     }
 
     @Override
-    public ActionResultType onItemUse(MaterialTool instance, ItemUseContext c) {
+    public ActionResultType onItemUse(IAntimatterTool instance, ItemUseContext c) {
         BlockState state = c.getWorld().getBlockState(c.getPos());
         if (state.has(BlockStateProperties.WATERLOGGED)) {
             if (state.get(BlockStateProperties.WATERLOGGED)) {

--- a/src/main/java/muramasa/antimatter/util/Utils.java
+++ b/src/main/java/muramasa/antimatter/util/Utils.java
@@ -43,6 +43,7 @@ import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
 import net.minecraft.world.dimension.DimensionType;
 import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.common.ToolType;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fml.DistExecutor;
@@ -617,14 +618,23 @@ public class Utils {
     }
 
     /**
-     * AntimatterToolType sensitive variant of BlockState::isToolEffective
+     * IAntimatterTool-sensitive extension of IForgeBlockState::isToolEffective
+     * @param tool IAntimatterTool derivatives
+     * @param state BlockState that is being checked against
+     * @return true if tool is effective by checking blocks or materials list of its AntimatterToolType
+     */
+    public static boolean isToolEffective(IAntimatterTool tool, BlockState state) {
+        return tool.getType().getEffectiveBlocks().contains(state.getBlock()) || tool.getType().getEffectiveMaterials().contains(state.getMaterial()) || tool.getToolTypes().stream().anyMatch(state::isToolEffective);
+    }
+
+    /**
+     * AntimatterToolType-sensitive extension of IForgeBlockState::isToolEffective
      * @param type AntimatterToolType object
      * @param state BlockState that is being checked against
      * @return true if tool is effective by checking blocks or materials list of its AntimatterToolType
      */
-    @Deprecated
-    public static boolean isToolEffective(AntimatterToolType type, BlockState state) {
-        return type.getToolTypes().stream().anyMatch(state::isToolEffective) || type.getEffectiveBlocks().contains(state.getBlock()) || type.getEffectiveMaterials().contains(state.getMaterial());
+    public static boolean isToolEffective(AntimatterToolType type, Set<ToolType> toolTypes, BlockState state) {
+        return type.getEffectiveBlocks().contains(state.getBlock()) || type.getEffectiveMaterials().contains(state.getMaterial()) || toolTypes.stream().anyMatch(state::isToolEffective);
     }
 
     /**
@@ -656,7 +666,7 @@ public class Utils {
             BlockPos pos;
             Direction[] dirs = { Direction.NORTH, Direction.EAST, Direction.SOUTH, Direction.WEST };
             while (amount > 0) {
-                if (blocks.isEmpty() || stack.getDamage() < 2) return false;
+                if (blocks.isEmpty() || (stack.isDamaged() && stack.getDamage() < tool.getType().getUseDurability())) return false;
                 pos = blocks.remove();
                 if (!visited.add(pos)) continue;
                 if (!world.getBlockState(pos).getBlock().isIn(BlockTags.LOGS)) continue;
@@ -666,8 +676,8 @@ public class Utils {
                 }
                 for (int x = 0; x < 3; x++)  {
                     for (int z = 0; z < 3; z++) {
-                        BlockPos acaciaPos = pos.add(-1 + x, 1, -1 + z);
-                        if (!visited.contains(acaciaPos)) blocks.add(acaciaPos);
+                        BlockPos branchPos = pos.add(-1 + x, 1, -1 + z);
+                        if (!visited.contains(branchPos)) blocks.add(branchPos);
                     }
                 }
                 amount--;
@@ -690,7 +700,7 @@ public class Utils {
      */
     public static ImmutableSet<BlockPos> getHarvestableBlocksToBreak(@Nonnull World world, @Nonnull PlayerEntity player, @Nonnull IAntimatterTool tool, int column, int row, int depth) {
         ImmutableSet<BlockPos> totalBlocks = getBlocksToBreak(world, player, column, row, depth);
-        return totalBlocks.stream().filter(b -> isToolEffective(tool.getType(), world.getBlockState(b))).collect(ImmutableSet.toImmutableSet());
+        return totalBlocks.stream().filter(b -> isToolEffective(tool, world.getBlockState(b))).collect(ImmutableSet.toImmutableSet());
     }
 
     /**
@@ -715,8 +725,7 @@ public class Utils {
             for (int y = 0; y < depth; y++) {
                 for (int x = isX ? -column : -row; x <= (isX ? column : row); x++) {
                     for (int z = isX ? -row : -column; z <= (isX ? row : column); z++) {
-                        if (x == 0 && y == 0 && z == 0) continue;
-                        else blockPositions.add(result.getPos().add(x, isDown ? y : -y, z));
+                        if (!(x == 0 && y == 0 && z == 0)) blockPositions.add(result.getPos().add(x, isDown ? y : -y, z));
                     }
                 }
             }
@@ -727,8 +736,7 @@ public class Utils {
             for (int x = 0; x < depth; x++) {
                 for (int y = -column; y <= column; y++) {
                     for (int z = -row; z <= row; z++) {
-                        if (x == 0 && y == 0 && z == 0) continue;
-                        else blockPositions.add(result.getPos().add(isX ? (isNegative ? x : -x) : (isNegative ? z : -z), y, isX ? (isNegative ? z : -z) : (isNegative ? x : -x)));
+                        if (!(x == 0 && y == 0 && z == 0)) blockPositions.add(result.getPos().add(isX ? (isNegative ? x : -x) : (isNegative ? z : -z), y, isX ? (isNegative ? z : -z) : (isNegative ? x : -x)));
                     }
                 }
             }


### PR DESCRIPTION
- Moved shovel behaviour to own class
- Electric tools in creative tabs/NEI now contain maximum stored energy
- Fix axes not treefelling when the item isn't damaged
- Fix quirky hoe related issues
- Made some behaviour sounds use tool's SoundEvent if there is one, if not, default to vanilla sound
- Made AntimatterToolType#getToolTypes return premature strings before they get the ToolType#get treatment. Instead, we do this in IAntimatterTool.
- Generified behaviours to IAntimatterTool and not just MaterialTool
- BehaviourBlockRotate now takes damage (config option to turn off?)
- When checking isToolEffective, check AntimatterToolType effective materials/blocks first, before resulting to stream#anyMatch#state::isToolEffective(ToolType)