### PR TITLE
Coremodding . . .

### DIFF
--- a/src/main/resources/META-INF/coremods.json
+++ b/src/main/resources/META-INF/coremods.json
@@ -1,0 +1,5 @@
+{
+
+  "AntimatterAPI transformer": "coremod/antimatterapi-transformer.js"
+
+}

--- a/src/main/resources/coremod/antimatterapi-transformer.js
+++ b/src/main/resources/coremod/antimatterapi-transformer.js
@@ -1,0 +1,38 @@
+function initializeCoreMod() {
+
+    var Opcodes = Java.type("org.objectweb.asm.Opcodes");
+    var IntInsnNode = Java.type("org.objectweb.asm.tree.IntInsnNode");
+    var MethodInsnNode = Java.type("org.objectweb.asm.tree.MethodInsnNode");
+
+    return {
+
+        "ServerWorld#notifyBlockUpdate": {
+
+            target: {
+
+                type: "METHOD",
+                class: "net.minecraft.world.server.ServerWorld",
+                methodName: "func_184138_a",
+                methodDesc: "(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;Lnet/minecraft/block/BlockState;I)V"
+
+            },
+
+            transformer: function(node) {
+
+                node.instructions.insert(new MethodInsnNode(Opcodes.INVOKESTATIC,
+                    "muramasa/antimatter/structure/StructureCache",
+                    "onNotifyBlockUpdate",
+                    "(Lnet/minecraft/world/server/ServerWorld;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;Lnet/minecraft/block/BlockState;)V"));
+                node.instructions.insert(new IntInsnNode(Opcodes.ALOAD, 3));
+                node.instructions.insert(new IntInsnNode(Opcodes.ALOAD, 2));
+                node.instructions.insert(new IntInsnNode(Opcodes.ALOAD, 1));
+                node.instructions.insert(new IntInsnNode(Opcodes.ALOAD, 0));
+
+                return node;
+
+            }
+
+        }
+    }
+
+}


### PR DESCRIPTION
- ServerWorld#notifyBlockUpdate now calls our StructureCache#onNotifyBlockUpdate
- This allows us to catch 99.99% of the cases where our multiblocks might be invalidated
- Saves us from having to listen to 2+ of Forge's slow events
- Can always add more checks in the HEAD of StructureCache#onNotifyBlockUpdate