### PR TITLE
basic multiblock take 2

### DIFF
--- a/src/main/java/muramasa/antimatter/machine/BlockMultiMachine.java
+++ b/src/main/java/muramasa/antimatter/machine/BlockMultiMachine.java
@@ -4,6 +4,7 @@ import muramasa.antimatter.client.AntimatterModelManager;
 import muramasa.antimatter.datagen.builder.AntimatterBlockModelBuilder;
 import muramasa.antimatter.datagen.providers.AntimatterBlockStateProvider;
 import muramasa.antimatter.machine.types.Machine;
+import muramasa.antimatter.tile.multi.TileEntityBasicMultiMachine;
 import muramasa.antimatter.tile.multi.TileEntityMultiMachine;
 import muramasa.antimatter.tool.MaterialTool;
 import net.minecraft.block.Block;
@@ -27,7 +28,7 @@ public class BlockMultiMachine extends BlockMachine {
     @Override
     protected ActionResultType onBlockActivatedBoth(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockRayTraceResult hit) {
         if (player.getHeldItem(hand).getItem() instanceof MaterialTool && ((MaterialTool) player.getHeldItem(hand).getItem()).getType() == HAMMER) {
-            TileEntityMultiMachine machine = (TileEntityMultiMachine) world.getTileEntity(pos);
+            TileEntityBasicMultiMachine machine = (TileEntityBasicMultiMachine) world.getTileEntity(pos);
             if (machine != null) {
                 if (!machine.isStructureValid()) {
                     machine.checkStructure();

--- a/src/main/java/muramasa/antimatter/machine/types/BasicMultiMachine.java
+++ b/src/main/java/muramasa/antimatter/machine/types/BasicMultiMachine.java
@@ -36,6 +36,7 @@ public class BasicMultiMachine extends Machine<BasicMultiMachine> {
         super(domain, name, getData(domain,data));
         setTile(() -> new TileEntityBasicMultiMachine(this));
         addFlags(MULTI, CONFIGURABLE, COVERABLE);
+        setGUI(Data.BASIC_MENU_HANDLER);
     }
 
     //TODO: How else to do this?

--- a/src/main/java/muramasa/antimatter/machine/types/BasicMultiMachine.java
+++ b/src/main/java/muramasa/antimatter/machine/types/BasicMultiMachine.java
@@ -1,0 +1,56 @@
+package muramasa.antimatter.machine.types;
+
+import muramasa.antimatter.AntimatterAPI;
+import muramasa.antimatter.Data;
+import muramasa.antimatter.machine.BlockMultiMachine;
+import muramasa.antimatter.machine.MachineState;
+import muramasa.antimatter.machine.Tier;
+import muramasa.antimatter.texture.ITextureHandler;
+import muramasa.antimatter.texture.Texture;
+import muramasa.antimatter.tile.multi.TileEntityBasicMultiMachine;
+import muramasa.antimatter.tile.multi.TileEntityMultiMachine;
+import net.minecraft.block.Block;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.Item;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static muramasa.antimatter.machine.MachineFlag.CONFIGURABLE;
+import static muramasa.antimatter.machine.MachineFlag.COVERABLE;
+import static muramasa.antimatter.machine.MachineFlag.MULTI;
+
+public class BasicMultiMachine extends Machine<BasicMultiMachine> {
+    @Override
+    protected Block getBlock(Machine<BasicMultiMachine> type, Tier tier) {
+        return new BlockMultiMachine(type, tier);
+    }
+
+    @Override
+    public Item getItem(Tier tier) {
+        return BlockItem.BLOCK_TO_ITEM.get(AntimatterAPI.get(BlockMultiMachine.class,this.getId() + "_" + tier.getId()));
+    }
+
+    public BasicMultiMachine(String domain, String name, Object... data) {
+        super(domain, name, getData(domain,data));
+        setTile(() -> new TileEntityBasicMultiMachine(this));
+        addFlags(MULTI, CONFIGURABLE, COVERABLE);
+    }
+
+    //TODO: How else to do this?
+    protected static Object[] getData(String domain, Object[] data) {
+        ArrayList<Object> arrayList = new ArrayList<>(Arrays.asList(data));
+        //Register a multi texture handler.
+        arrayList.add((ITextureHandler) (type, tier) -> type.getTiers().size() > 1 ? new Texture[]{new Texture(domain, "block/machine/base/" + type.getId() + "_" + tier.getId())} : new Texture[]{new Texture(domain, "block/machine/base/" + type.getId())});
+        return arrayList.toArray(new Object[0]);
+    }
+
+    @Override
+    public List<Texture> getTextures() {
+        List<Texture> textures = super.getTextures();
+        getTiers().forEach(t -> textures.addAll(Arrays.asList(getBaseTexture(t))));
+        textures.addAll(Arrays.asList(getOverlayTextures(MachineState.INVALID_STRUCTURE)));
+        return textures;
+    }
+}

--- a/src/main/java/muramasa/antimatter/machine/types/MultiMachine.java
+++ b/src/main/java/muramasa/antimatter/machine/types/MultiMachine.java
@@ -18,37 +18,11 @@ import java.util.List;
 
 import static muramasa.antimatter.machine.MachineFlag.*;
 
-public class MultiMachine extends Machine<MultiMachine> {
-    @Override
-    protected Block getBlock(Machine<MultiMachine> type, Tier tier) {
-        return new BlockMultiMachine(type, tier);
-    }
-
-    @Override
-    public Item getItem(Tier tier) {
-        return BlockItem.BLOCK_TO_ITEM.get(AntimatterAPI.get(BlockMultiMachine.class,this.getId() + "_" + tier.getId()));
-    }
+public class MultiMachine extends BasicMultiMachine {
 
     public MultiMachine(String domain, String name, Object... data) {
-        super(domain, name, getData(domain,data));
+        super(domain, name, data);
         setTile(() -> new TileEntityMultiMachine(this));
-        addFlags(MULTI, CONFIGURABLE, COVERABLE);
         setGUI(Data.MULTI_MENU_HANDLER);
-    }
-
-    //TODO: How else to do this?
-    protected static Object[] getData(String domain, Object[] data) {
-        ArrayList<Object> arrayList = new ArrayList<>(Arrays.asList(data));
-        //Register a multi texture handler.
-        arrayList.add((ITextureHandler) (type, tier) -> type.getTiers().size() > 1 ? new Texture[]{new Texture(domain, "block/machine/base/" + type.getId() + "_" + tier.getId())} : new Texture[]{new Texture(domain, "block/machine/base/" + type.getId())});
-        return arrayList.toArray(new Object[0]);
-    }
-
-    @Override
-    public List<Texture> getTextures() {
-        List<Texture> textures = super.getTextures();
-        getTiers().forEach(t -> textures.addAll(Arrays.asList(getBaseTexture(t))));
-        textures.addAll(Arrays.asList(getOverlayTextures(MachineState.INVALID_STRUCTURE)));
-        return textures;
     }
 }

--- a/src/main/java/muramasa/antimatter/structure/StructureCache.java
+++ b/src/main/java/muramasa/antimatter/structure/StructureCache.java
@@ -3,6 +3,7 @@ package muramasa.antimatter.structure;
 import it.unimi.dsi.fastutil.longs.*;
 import muramasa.antimatter.Antimatter;
 import muramasa.antimatter.AntimatterAPI;
+import muramasa.antimatter.tile.multi.TileEntityBasicMultiMachine;
 import muramasa.antimatter.tile.multi.TileEntityMultiMachine;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.RegistryKey;
@@ -66,7 +67,7 @@ public class StructureCache {
 
     private static void invalidateController(World world, BlockPos pos) {
         TileEntity tile = world.getTileEntity(pos);
-        if (tile instanceof TileEntityMultiMachine) ((TileEntityMultiMachine) tile).invalidateStructure();
+        if (tile instanceof TileEntityBasicMultiMachine) ((TileEntityBasicMultiMachine) tile).invalidateStructure();
         remove(world, pos);
     }
 

--- a/src/main/java/muramasa/antimatter/tile/TileEntityMachine.java
+++ b/src/main/java/muramasa/antimatter/tile/TileEntityMachine.java
@@ -30,6 +30,7 @@ import muramasa.antimatter.network.packets.TileGuiEventPacket;
 import muramasa.antimatter.recipe.Recipe;
 import muramasa.antimatter.structure.StructureCache;
 import muramasa.antimatter.texture.Texture;
+import muramasa.antimatter.tile.multi.TileEntityBasicMultiMachine;
 import muramasa.antimatter.tile.multi.TileEntityMultiMachine;
 import muramasa.antimatter.tool.AntimatterToolType;
 import muramasa.antimatter.util.Utils;
@@ -301,7 +302,7 @@ public class TileEntityMachine extends TileEntityTickable implements INamedConta
         coverHandler.ifPresent(machineCoverHandler -> builder.withInitial(AntimatterProperties.MACHINE_TILE, this));
         BlockPos cPos = StructureCache.get(this.getWorld(), pos);
         if (cPos != null) {
-            TileEntityMultiMachine mTile = (TileEntityMultiMachine) world.getTileEntity(cPos);
+            TileEntityBasicMultiMachine mTile = (TileEntityBasicMultiMachine) world.getTileEntity(cPos);
             builder.withInitial(AntimatterProperties.MULTI_MACHINE_TEXTURE,a -> {
                 Texture[] tex = mTile.getMachineType().getBaseTexture(mTile.getMachineTier());
                 if (tex.length == 1) return tex[0];

--- a/src/main/java/muramasa/antimatter/tile/multi/TileEntityBasicMultiMachine.java
+++ b/src/main/java/muramasa/antimatter/tile/multi/TileEntityBasicMultiMachine.java
@@ -1,12 +1,15 @@
 package muramasa.antimatter.tile.multi;
 
+import muramasa.antimatter.capability.AntimatterCaps;
 import muramasa.antimatter.capability.IComponentHandler;
+import muramasa.antimatter.capability.machine.ControllerComponentHandler;
 import muramasa.antimatter.capability.machine.MultiMachineEnergyHandler;
 import muramasa.antimatter.capability.machine.MultiMachineFluidHandler;
 import muramasa.antimatter.capability.machine.MultiMachineItemHandler;
 import muramasa.antimatter.machine.MachineState;
 import muramasa.antimatter.machine.types.Machine;
 import muramasa.antimatter.registration.IAntimatterObject;
+import muramasa.antimatter.structure.IComponent;
 import muramasa.antimatter.structure.Structure;
 import muramasa.antimatter.structure.StructureCache;
 import muramasa.antimatter.structure.StructureResult;
@@ -14,15 +17,20 @@ import muramasa.antimatter.tile.TileEntityMachine;
 import muramasa.antimatter.util.Utils;
 import net.minecraft.block.BlockState;
 import net.minecraft.util.Direction;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.util.LazyOptional;
 
+import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
 /** Allows a MultiMachine to handle GUI recipes, instead of using Hatches **/
-public class TileEntityBasicMultiMachine extends TileEntityMachine {
+public class TileEntityBasicMultiMachine extends TileEntityMachine implements IComponent {
 
     protected Optional<StructureResult> result = Optional.empty();
+
+    protected final LazyOptional<ControllerComponentHandler> componentHandler = LazyOptional.of(() -> new ControllerComponentHandler(this));
 
     public TileEntityBasicMultiMachine(Machine<?> type) {
         super(type);
@@ -152,5 +160,19 @@ public class TileEntityBasicMultiMachine extends TileEntityMachine {
     @Override
     public MachineState getDefaultMachineState() {
         return MachineState.INVALID_STRUCTURE;
+    }
+
+    @Override
+    public LazyOptional<ControllerComponentHandler> getComponentHandler() {
+        return componentHandler;
+    }
+
+    @Nonnull
+    @Override
+    public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> cap, Direction side) {
+        if (cap == AntimatterCaps.COMPONENT_HANDLER_CAPABILITY && componentHandler.isPresent()) {
+            return componentHandler.cast();
+        }
+        return super.getCapability(cap, side);
     }
 }

--- a/src/main/java/muramasa/antimatter/tile/multi/TileEntityBasicMultiMachine.java
+++ b/src/main/java/muramasa/antimatter/tile/multi/TileEntityBasicMultiMachine.java
@@ -148,4 +148,9 @@ public class TileEntityBasicMultiMachine extends TileEntityMachine {
     public void onStructureInvalidated() {
         //NOOP
     }
+
+    @Override
+    public MachineState getDefaultMachineState() {
+        return MachineState.INVALID_STRUCTURE;
+    }
 }

--- a/src/main/java/muramasa/antimatter/tile/multi/TileEntityBasicMultiMachine.java
+++ b/src/main/java/muramasa/antimatter/tile/multi/TileEntityBasicMultiMachine.java
@@ -1,45 +1,151 @@
 package muramasa.antimatter.tile.multi;
 
+import muramasa.antimatter.capability.IComponentHandler;
+import muramasa.antimatter.capability.machine.MultiMachineEnergyHandler;
+import muramasa.antimatter.capability.machine.MultiMachineFluidHandler;
+import muramasa.antimatter.capability.machine.MultiMachineItemHandler;
+import muramasa.antimatter.machine.MachineState;
 import muramasa.antimatter.machine.types.Machine;
+import muramasa.antimatter.registration.IAntimatterObject;
+import muramasa.antimatter.structure.Structure;
+import muramasa.antimatter.structure.StructureCache;
+import muramasa.antimatter.structure.StructureResult;
+import muramasa.antimatter.tile.TileEntityMachine;
+import muramasa.antimatter.util.Utils;
+import net.minecraft.block.BlockState;
+import net.minecraft.util.Direction;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 /** Allows a MultiMachine to handle GUI recipes, instead of using Hatches **/
-public class TileEntityBasicMultiMachine extends TileEntityMultiMachine {
+public class TileEntityBasicMultiMachine extends TileEntityMachine {
+
+    protected Optional<StructureResult> result = Optional.empty();
 
     public TileEntityBasicMultiMachine(Machine<?> type) {
         super(type);
-        // TODO
-        /*
-        recipeHandler.setup((tile, tag) -> new MultiMachineRecipeHandler<TileEntityMultiMachine>(tile, tag) {
-            @Override
-            public Recipe findRecipe() { //TODO support fluids?
-                return getMachineType().getRecipeMap().find(itemHandler.get(), null);
-            }
+    }
 
-            @Override
-            public void consumeInputs() {
-                itemHandler.ifPresent(h -> h.consumeInputs(activeRecipe,false));
-            }
+    @Override
+    public void onRemove() {
+        super.onRemove();
+        invalidateStructure();
+    }
 
-            @Override
-            public boolean canOutput() {
-                return itemHandler.isPresent() && itemHandler.get().canOutputsFit(activeRecipe.getOutputItems());
-            }
+    @Override
+    public void onFirstTick() {
+        if (!isStructureValid()) {
+            checkStructure();
+        }
+        super.onFirstTick();
+    }
 
-            @Override
-            public void addOutputs() {
-                itemHandler.ifPresent(h -> h.addOutputs(activeRecipe.getOutputItems()));
-            }
-
-            @Override
-            public boolean canRecipeContinue() {
-                return itemHandler.isPresent() && Utils.doItemsMatchAndSizeValid(activeRecipe.getInputItems(), itemHandler.get().getInputs());
-            }
-
-            @Override
-            public boolean consumeResourceForRecipe() {
+    public boolean checkStructure() {
+        Structure structure = getMachineType().getStructure(getMachineTier());
+        if (structure == null) return false;
+        StructureResult result = structure.evaluate(this);
+        if (result.evaluate()) {
+            this.result = Optional.of(result);
+            StructureCache.add(world, pos, result.positions);
+            if (isServerSide()) {
+                if (onStructureFormed()) {
+                    afterStructureFormed();
+                    setMachineState(MachineState.IDLE);
+                    System.out.println("[Structure Debug] Valid Structure");
+                    if (hadFirstTick()) this.recipeHandler.ifPresent(t -> {
+                        if (t.hasRecipe())
+                            setMachineState(MachineState.NO_POWER);
+                        else {
+                            t.checkRecipe();
+                        }
+                    });
+                    sidedSync(true);
+                    return true;
+                }
+            } else {
+                this.result.ifPresent(r -> r.components.forEach((k, v) -> v.forEach(c -> {
+                    Utils.markTileForRenderUpdate(c.getTile());
+                })));
+                sidedSync(true);
                 return true;
             }
-        });
-         */
+        } else {
+            invalidateStructure();
+        }
+        return false;
+    }
+
+    @Override
+    public boolean setFacing(Direction side) {
+        boolean ok = super.setFacing(side);
+        if (ok) {
+            checkStructure();
+        }
+        return ok;
+    }
+
+    public void invalidateStructure() {
+        if (removed) return;
+        if (!result.isPresent()) return;
+        StructureCache.remove(this.getWorld(), getPos());
+        if (isServerSide()) {
+            onStructureInvalidated();
+            result = Optional.empty();
+            resetMachine();
+        } else {
+            this.result.ifPresent(r -> r.components.forEach((k, v) -> v.forEach(c -> {
+                Utils.markTileForRenderUpdate(c.getTile());
+            })));
+            result = Optional.empty();
+        }
+    }
+
+    @Override
+    public void onServerUpdate() {
+        super.onServerUpdate();
+        if (!result.isPresent() && world != null && world.getGameTime() % 200 == 0) {
+            //Uncomment to periodically check structure.
+            // checkStructure();
+        }
+    }
+
+    /** Returns a list of Components **/
+    public List<IComponentHandler> getComponents(IAntimatterObject object) {
+        return getComponents(object.getId());
+    }
+
+    public List<IComponentHandler> getComponents(String id) {
+        if (result.isPresent()) {
+            List<IComponentHandler> list = result.get().components.get(id);
+            return list != null ? list : Collections.emptyList();
+        }
+        return Collections.emptyList();
+    }
+
+    public List<BlockState> getStates(String id) {
+        if (result.isPresent()) {
+            List<BlockState> list = result.get().states.get(id);
+            return list != null ? list : Collections.emptyList();
+        }
+        return Collections.emptyList();
+    }
+
+    public boolean isStructureValid() {
+        return StructureCache.has(world, pos);
+    }
+
+    /** Events **/
+    public boolean onStructureFormed() {
+        return true;
+    }
+
+    public void afterStructureFormed(){
+        //NOOP
+    }
+
+    public void onStructureInvalidated() {
+        //NOOP
     }
 }

--- a/src/main/java/muramasa/antimatter/tile/multi/TileEntityMultiMachine.java
+++ b/src/main/java/muramasa/antimatter/tile/multi/TileEntityMultiMachine.java
@@ -32,12 +32,10 @@ import java.util.Optional;
 
 import static muramasa.antimatter.machine.MachineFlag.*;
 
-public class TileEntityMultiMachine extends TileEntityBasicMultiMachine implements IComponent {
+public class TileEntityMultiMachine extends TileEntityBasicMultiMachine {
 
     protected int efficiency, efficiencyIncrease; //TODO move to BasicMachine
     protected long EUt;
-
-    protected final LazyOptional<ControllerComponentHandler> componentHandler = LazyOptional.of(() -> new ControllerComponentHandler(this));
 
     //TODO: Sync multiblock state(if it is formed), otherwise the textures might bug out. Not a big deal.
     public TileEntityMultiMachine(Machine<?> type) {
@@ -212,19 +210,5 @@ public class TileEntityMultiMachine extends TileEntityBasicMultiMachine implemen
     public int getMaxInputVoltage() {
         List<IComponentHandler> hatches = getComponents("hatch_energy");
         return hatches.size() >= 1 ? hatches.stream().mapToInt(t -> t.getEnergyHandler().map(eh -> eh.getInputAmperage()*eh.getInputVoltage()).orElse(0)).sum() : Ref.V[0];
-    }
-
-    @Override
-    public LazyOptional<ControllerComponentHandler> getComponentHandler() {
-        return componentHandler;
-    }
-
-    @Nonnull
-    @Override
-    public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> cap, Direction side) {
-        if (cap == AntimatterCaps.COMPONENT_HANDLER_CAPABILITY && componentHandler.isPresent()) {
-            return componentHandler.cast();
-        }
-        return super.getCapability(cap, side);
     }
 }

--- a/src/main/java/muramasa/antimatter/tile/multi/TileEntityMultiMachine.java
+++ b/src/main/java/muramasa/antimatter/tile/multi/TileEntityMultiMachine.java
@@ -39,8 +39,6 @@ public class TileEntityMultiMachine extends TileEntityBasicMultiMachine implemen
 
     protected final LazyOptional<ControllerComponentHandler> componentHandler = LazyOptional.of(() -> new ControllerComponentHandler(this));
 
-    protected Optional<StructureResult> result = Optional.empty();
-
     //TODO: Sync multiblock state(if it is formed), otherwise the textures might bug out. Not a big deal.
     public TileEntityMultiMachine(Machine<?> type) {
         super(type);
@@ -50,17 +48,12 @@ public class TileEntityMultiMachine extends TileEntityBasicMultiMachine implemen
     }
 
     @Override
-    public void onRemove() {
-        super.onRemove();
-        invalidateStructure();
-    }
-
-    @Override
     public Tier getPowerLevel() {
         return energyHandler.map(t -> ((MultiMachineEnergyHandler)t).getAccumulatedPower()).orElse(super.getPowerLevel());
     }
 
-    public void afterStructurePoint(){
+    @Override
+    public void afterStructureFormed(){
         this.result.ifPresent(r -> r.components.forEach((k, v) -> v.forEach(c -> {
             c.onStructureFormed(this);
         })));
@@ -224,11 +217,6 @@ public class TileEntityMultiMachine extends TileEntityBasicMultiMachine implemen
     @Override
     public LazyOptional<ControllerComponentHandler> getComponentHandler() {
         return componentHandler;
-    }
-
-    @Override
-    public MachineState getDefaultMachineState() {
-        return MachineState.INVALID_STRUCTURE;
     }
 
     @Nonnull


### PR DESCRIPTION
This seems like a good way to do it, having TileEntityMultiMachine extend TileEntityBasicMultimachine removes duplicate code, and it makes more sense cause honestly a multiblock should either use slots or hatches, it makes no sense for it to use both
Only issue I seem to have run into is any MultiMAchines have to be cast to MultiMachine if you use any of the methods like setTile, cause of the fact I made MultiMachine extend a BasicMultiMachine, which extends Machine