### PR TITLE
Store distillation input amount in a material tag

### DIFF
--- a/common/src/main/java/muramasa/antimatter/event/MaterialEvent.java
+++ b/common/src/main/java/muramasa/antimatter/event/MaterialEvent.java
@@ -28,10 +28,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static muramasa.antimatter.Data.*;
-import static muramasa.antimatter.material.MaterialTags.ARMOR;
-import static muramasa.antimatter.material.MaterialTags.DISTILL_INTO;
-import static muramasa.antimatter.material.MaterialTags.HANDLE;
-import static muramasa.antimatter.material.MaterialTags.METAL;
+import static muramasa.antimatter.material.MaterialTags.*;
 
 public class MaterialEvent {
     private Material material = Data.NULL;
@@ -146,6 +143,7 @@ public class MaterialEvent {
         MaterialTags.FUEL_POWER.add(this.material, fuelPower);
         MaterialTags.LIQUID_TEMPERATURE.add(this.material, temp);
         if (canDistill){
+            DISTILLATION_FLUID_INPUT_AMOUNT.add(this.material, distillationAmount);
             DISTILL_INTO.add(this.material, Arrays.stream(distillationProducts).toList());
         }
         return this;
@@ -169,6 +167,7 @@ public class MaterialEvent {
         MaterialTags.FUEL_POWER.add(this.material, fuelPower);
         MaterialTags.GAS_TEMPERATURE.add(this.material, temp);
         if (canDistill){
+            DISTILLATION_FLUID_INPUT_AMOUNT.add(this.material, distillationAmount);
             DISTILL_INTO.add(this.material, Arrays.stream(distillationProducts).toList());
         }
         return this;

--- a/common/src/main/java/muramasa/antimatter/material/MaterialTags.java
+++ b/common/src/main/java/muramasa/antimatter/material/MaterialTags.java
@@ -68,6 +68,7 @@ public class MaterialTags {
     public static final ListMaterialTag<Material> BYPRODUCTS = new ListMaterialTag<>("byproducts");
 
     public static final ListMaterialTag<FluidProduct> DISTILL_INTO = new ListMaterialTag<>("distill_into");
+    public static final NumberMaterialTag DISTILLATION_FLUID_INPUT_AMOUNT = new NumberMaterialTag("distillation_fluid_input_amount");
 
 
     public static final BlockDropMaterialTag<BlockOre> CUSTOM_ORE_DROPS = new BlockDropMaterialTag<>("custom_ore_drops");


### PR DESCRIPTION
Looking at this as part of https://github.com/GregTech-Intergalactical/GregTech/pull/136.

We need to get the input amount per material into the distillery loader and I'm thinking we just use a material tag similar to what is done for things like blast furnace temp or power.